### PR TITLE
docs: plan strict contract editor support and release quality

### DIFF
--- a/docs/plans/2026-04-27-editor-ide-quality-release-design.md
+++ b/docs/plans/2026-04-27-editor-ide-quality-release-design.md
@@ -1,0 +1,171 @@
+---
+status: ready-for-implementation
+implementation_status: not-started
+scope:
+  - workflow-editor
+  - workflow-vscode
+  - workflow-jetbrains
+tracks:
+  - playwright
+  - e2e
+  - release
+  - ide-compatibility
+  - local-static-analysis
+---
+
+# Editor and IDE Quality, Usability, and Release Independence
+
+**Date:** 2026-04-27
+**Status:** Ready for implementation after Workflow PR 500 is merged
+**Repos:** workflow-editor, workflow-vscode, workflow-jetbrains, workflow
+
+## Overview
+
+`workflow-editor` is now a shared authoring surface for standalone editor usage, VS Code, JetBrains, and Workflow-driven projects. It has strong unit coverage in some schema and serialization areas, but the actual release path still has gaps:
+
+- E2E tests exist but are not part of CI.
+- Several early Playwright tests are placeholders.
+- Local `npm test` currently fails under Node 25 with a `localStorage` persistence issue, while CI pins Node 22.
+- Editor releases are usually triggered by Workflow releases, making editor-only fixes harder to publish independently.
+- IDE plugin syncs consume editor releases, but IDE compatibility and smoke tests are not strong enough.
+- `wfctl.yaml` and IaC YAML are not covered consistently in editor or IDE workflows.
+
+This design makes release quality explicit and gives the editor a path to ship between Workflow releases.
+
+## Current Release Shape
+
+```mermaid
+graph TD
+  A[workflow release] -->|repository_dispatch workflow-release| B[workflow-editor sync-schema]
+  B --> C[regenerate schemas]
+  C --> D[npm test + build]
+  D --> E[publish editor package]
+  E --> F[commit and tag]
+  F --> G[dispatch editor-release]
+  G --> H[workflow-vscode sync]
+  G --> I[workflow-jetbrains sync]
+```
+
+Problems:
+
+- `sync-schema.yml` publishes before committing/tagging generated changes.
+- `sync-schema.yml` does not run Playwright E2E tests.
+- `build.yml` does not run Playwright E2E tests.
+- `publish.yml` is manual fallback only and does not support a normal editor-only release train.
+- IDE plugin tests do not prove the webview is usable after package bumps.
+- JetBrains declares conflicting compatibility in code vs README.
+
+## Target Release Shape
+
+```mermaid
+graph TD
+  A[workflow release] --> B[schema sync PR or direct sync]
+  C[editor-only change] --> D[editor release workflow]
+  B --> E[editor CI gate]
+  D --> E
+  E --> F[npm publish]
+  F --> G[tag editor release]
+  G --> H[dispatch IDE sync]
+  H --> I[VS Code CI + smoke]
+  H --> J[JetBrains CI + verifier]
+```
+
+Key changes:
+
+- Editor has first-class editor-only release workflow.
+- Workflow release sync is one input into editor releases, not the only path.
+- CI gates include TypeScript, unit tests, build, Playwright E2E, and static analysis.
+- IDE sync PRs or branches run compatibility checks before release.
+
+## Testing Strategy
+
+### Unit and Integration Tests
+
+Keep current Vitest coverage and add missing global test setup:
+
+- Stable `localStorage` implementation for Zustand persistence in test environment.
+- No accidental reliance on Node-specific browser globals.
+- Schema and serialization tests for `app.yaml`, `infra.yaml`, and `wfctl.yaml`.
+- Editor bundle tests from the strict contract plan.
+
+### Playwright E2E
+
+Convert placeholder tests into real workflows:
+
+- Load sample app YAML and verify nodes render.
+- Add a node from palette and verify canvas plus YAML update.
+- Select node, edit property, verify YAML update.
+- Open YAML pane, edit/select lines, verify canvas selection.
+- Use DSL reference pane and verify context-sensitive navigation.
+- Load multi-file workspace and verify cross-file navigation.
+- Load strict-contract sample bundle and verify contract indicators.
+- Load IaC/wfctl sample workspace and verify file-type presentation.
+
+E2E matrix:
+
+- Desktop Chromium in CI for every PR.
+- Optional local WebKit/Firefox smoke for release candidates.
+- Screenshots/videos retained on failure.
+
+### Exploratory Testing
+
+Add a repeatable Playwright CLI checklist for human/agent-driven exploratory testing:
+
+- Standalone browser editor.
+- VS Code webview.
+- JetBrains webview.
+- Multi-file Workflow app.
+- IaC/wfctl project config.
+- Strict-contract plugin sample.
+
+Exploration outputs should be stored as short markdown notes or CI artifacts, not buried in chat.
+
+### Static Analysis and Local Quality
+
+Add or enable:
+
+- `npm run lint` in CI once ESLint config is stable.
+- `npm audit --audit-level=high` as an advisory check initially, then a required check after current high vulnerabilities are triaged.
+- TypeScript `npx tsc --noEmit`.
+- Playwright E2E in CI.
+- Package manager and Node version pinning with `.nvmrc` or `.node-version`.
+
+## IDE Compatibility
+
+VS Code:
+
+- Keep extension engine compatibility explicit.
+- Run compile/test/package on sync PRs.
+- Add a minimal extension host test for opening a Workflow YAML and loading the editor webview.
+- Add schema association tests for `app.yaml`, `infra.yaml`, and `wfctl.yaml`.
+
+JetBrains:
+
+- Resolve README vs `sinceBuild` mismatch.
+- Run Gradle test/build and plugin verifier for the declared compatibility window.
+- Add smoke tests for webview asset loading after editor sync.
+- Add file-type/schema association tests for `app.yaml`, `infra.yaml`, and `wfctl.yaml`.
+
+## Release Independence
+
+Editor releases should support:
+
+- `workflow-release` dispatch for schema/bundle sync.
+- Manual `workflow_dispatch` for editor-only patches.
+- Tag-driven release from `workflow-editor` without requiring a new Workflow tag.
+- IDE dispatch using the actual editor package version, not necessarily the Workflow version.
+
+Versioning:
+
+- If generated Workflow schema/bundle changes, editor version may match Workflow for compatibility.
+- If editor-only code changes, bump patch version independently.
+- IDE plugins should consume `@gocodealone/workflow-editor` by exact released version after sync, not broad ranges in generated release branches.
+
+## Acceptance Criteria
+
+- `workflow-editor` CI runs TypeScript, Vitest, build, and Playwright E2E.
+- Placeholder Playwright tests are replaced with real user workflows.
+- Local tests run consistently on the documented Node version.
+- Editor can publish an editor-only release and dispatch IDE syncs.
+- VS Code and JetBrains sync workflows run compatibility checks before publishing or tagging.
+- `app.yaml`, `infra.yaml`, and `wfctl.yaml` are covered in editor and IDE tests.

--- a/docs/plans/2026-04-27-editor-ide-quality-release-implementation.md
+++ b/docs/plans/2026-04-27-editor-ide-quality-release-implementation.md
@@ -1,0 +1,164 @@
+---
+status: ready-for-implementation
+implementation_status: not-started
+depends_on:
+  - docs/plans/2026-04-27-editor-ide-quality-release-design.md
+  - Workflow PR 500 merged
+---
+
+# Editor and IDE Quality Release Implementation Plan
+
+> **For agents:** REQUIRED SUB-SKILLS: use `superpowers:executing-plans`, `superpowers:test-driven-development`, `superpowers:runtime-launch-validation`, `superpowers:requesting-code-review`, and `superpowers:verification-before-completion`. Use an implementer plus an antagonistic code reviewer. Do not start this implementation until the current Workflow checksum PR is merged or explicitly cleared.
+
+**Goal:** Make editor and IDE releases independently shippable with reliable unit, E2E, exploratory, and compatibility gates.
+
+**Design Doc:** `docs/plans/2026-04-27-editor-ide-quality-release-design.md`
+
+## Phase 1: Stabilize Local and CI Test Baseline
+
+**Repo:** workflow-editor
+
+1. Add a test setup file if one does not already exist.
+   - Provide a browser-compatible `localStorage` mock with `getItem`, `setItem`, `removeItem`, and `clear`.
+   - Ensure Zustand persistence tests do not depend on Node version quirks.
+
+2. Pin the supported local Node version.
+   - Add `.nvmrc` or `.node-version` with the CI version, currently Node 22.
+   - Document the version in README or package scripts if README exists later.
+
+3. Add focused tests for the storage setup.
+   - Prove `npm test` can reset stores without `storage.setItem is not a function`.
+
+4. Verification:
+   - `npm test`
+   - `npx tsc --noEmit`
+   - `npm run build`
+
+## Phase 2: Turn Playwright Into a Required Gate
+
+**Repo:** workflow-editor
+
+1. Replace placeholder E2E tests in `e2e/editor.spec.ts`.
+   - Load a sample Workflow config through the harness.
+   - Add a node from the palette.
+   - Edit node config and assert YAML changes.
+   - Verify YAML pane selection round-trip.
+   - Verify DSL reference pane renders and navigates.
+
+2. Add scenarios to `e2e/test-app`.
+   - `strict-contracts`
+   - `iac-wfctl-files`
+   - `editor-bundle`
+
+3. Update CI.
+   - Add browser install/cache if needed.
+   - Run `npm run test:e2e` in `.github/workflows/build.yml`.
+   - Retain Playwright report artifacts on failure.
+
+4. Verification:
+   - `npm run test:e2e`
+   - CI run on PR.
+
+## Phase 3: Add Static Analysis and Security Gates
+
+**Repo:** workflow-editor
+
+1. Make ESLint runnable in CI.
+   - Fix or scope existing lint issues.
+   - Add `npm run lint` to build workflow.
+
+2. Add npm audit gate.
+   - Start as non-blocking with uploaded output if current vulnerabilities need triage.
+   - Create issues or plan entries for remaining high vulnerabilities.
+   - Move to blocking at `--audit-level=high` after triage.
+
+3. Verification:
+   - `npm run lint`
+   - `npm audit --audit-level=high` or documented non-blocking CI step.
+
+## Phase 4: Editor-Only Release Workflow
+
+**Repo:** workflow-editor
+
+1. Add an editor release workflow.
+   - Trigger: `workflow_dispatch` with version input and optional prerelease flag.
+   - Trigger: tag push for editor-owned tags if preferred by repo convention.
+   - Gates: install, TypeScript, unit tests, Playwright, build, publish.
+
+2. Fix publish ordering in schema sync.
+   - Commit/tag generated schema/bundle changes before publish where practical.
+   - Publish exact package contents that correspond to the tag.
+
+3. Dispatch IDE syncs with the editor package version.
+   - Do not assume editor version always equals Workflow version.
+   - Include Workflow compatibility metadata in payload when schema/bundle sync came from Workflow release.
+
+4. Verification:
+   - Dry-run workflow commands locally where possible.
+   - Manual workflow dispatch on a test version or dry-run branch if supported.
+
+## Phase 5: VS Code Sync and Compatibility
+
+**Repo:** workflow-vscode
+
+1. Update sync workflow.
+   - Consume editor release payload version exactly.
+   - Run compile/test/package before publishing or merging.
+
+2. Add schema associations.
+   - `app.yaml`, `app.yml`
+   - `infra.yaml`, `infra.yml`
+   - `wfctl.yaml`, `wfctl.yml`
+
+3. Add extension host smoke test.
+   - Open a fixture Workflow project.
+   - Verify editor webview loads.
+   - Verify schema diagnostics activate.
+
+4. Verification:
+   - `npm test`
+   - compile/package command from repo scripts.
+
+## Phase 6: JetBrains Sync and Compatibility
+
+**Repo:** workflow-jetbrains
+
+1. Resolve compatibility metadata.
+   - Align README and `sinceBuild`.
+   - Define supported IDE version window.
+
+2. Update sync workflow.
+   - Consume editor release payload version exactly.
+   - Run Gradle tests/build.
+   - Run plugin verifier for supported IDE versions.
+
+3. Add file association and webview smoke tests.
+   - `app.yaml`, `infra.yaml`, `wfctl.yaml`.
+   - Editor asset load after package sync.
+
+4. Verification:
+   - `./gradlew test`
+   - `./gradlew buildPlugin`
+   - plugin verifier task for declared IDE versions.
+
+## Phase 7: Exploratory Playwright CLI Runbook
+
+**Repo:** workflow-editor
+
+1. Add `docs/testing/exploratory-editor-playwright.md`.
+   - Commands to launch harness.
+   - Playwright CLI flows for canvas, YAML, strict contracts, and IaC/wfctl files.
+   - Expected screenshots or assertions.
+
+2. Add a release checklist item requiring an exploratory pass for major editor UI changes.
+
+3. Verification:
+   - Run the checklist once and record findings in `docs/iteration-log.md` or CI artifacts.
+
+## Rollout
+
+1. Land `workflow-editor` baseline/test/release improvements.
+2. Release an editor-only patch version.
+3. Let VS Code and JetBrains sync from that editor release.
+4. Confirm both IDE plugin workflows pass compatibility checks.
+5. Then start the strict-contract editor implementation if not already in progress.

--- a/docs/plans/2026-04-27-strict-grpc-contract-editor-support-design.md
+++ b/docs/plans/2026-04-27-strict-grpc-contract-editor-support-design.md
@@ -1,0 +1,187 @@
+---
+status: ready-for-implementation
+implementation_status: not-started
+scope:
+  - workflow
+  - workflow-editor
+  - workflow-vscode
+  - workflow-jetbrains
+tracks:
+  - strict-grpc-contracts
+  - editor-schema-export
+  - wfctl-yaml
+  - iac-yaml
+---
+
+# Strict gRPC Contract Support in Workflow Editor and IDEs
+
+**Date:** 2026-04-27
+**Status:** Ready for implementation after Workflow PR 500 is merged
+**Repos:** workflow, workflow-editor, workflow-vscode, workflow-jetbrains
+
+## Overview
+
+Workflow's strict gRPC go-plugin contract mode gives plugins typed module, step, service, and message descriptors. The editor stack currently consumes module schemas, step schemas, coercion rules, and DSL reference data, but it does not understand strict contract mode, plugin contract metadata, descriptor-backed message types, or `wfctl.yaml` project metadata.
+
+The goal is to make strict contracts visible and actionable across the full authoring surface:
+
+- `wfctl` exports a canonical editor contract bundle.
+- `workflow-editor` loads and presents strict contract metadata for built-in and plugin-provided nodes.
+- Node palettes, property panels, validation, YAML round-trip, and connection compatibility understand typed inputs and outputs.
+- VS Code and JetBrains plugins associate `app.yaml`, `infra.yaml`, and `wfctl.yaml` with the right schemas and pass the same contract bundle into the editor webview.
+
+## Current Gaps
+
+`workflow-editor` has these gaps:
+
+- `src/generated/load-schemas.ts` only loads `moduleSchemas`, `stepSchemas`, and `coercionRules`.
+- `PluginSchemaData` only supports plugin module schemas; there is no contract registry, step contract, message descriptor, or strict-mode flag.
+- The palette can label plugin-provided module types through `pluginSource`, but does not show contract mode, strictness, or descriptor provenance.
+- The property panel can render `ConfigFieldDef` fields, but cannot show typed message schemas, request/response payload contracts, or descriptor-backed nested forms.
+- Validation is mostly parse-time and test-time. There is no live AJV/schema validation of authoring data against a contract bundle and no `wfctl validate` bridge for host environments.
+- `wfctl.yaml` is not modeled as an editor-supported file, schema, or IDE-associated file type.
+- IaC DSL support exists only indirectly through generated modules and steps; top-level `infrastructure`, `sidecars`, provider state, and `wfctl` project config are not first-class authoring surfaces.
+
+The Workflow side has these gaps:
+
+- The strict contract work already introduces `ContractRegistry`, `ContractDescriptor`, strict/proto-with-legacy modes, descriptor sets, SDK provider interfaces, and `wfctl plugin init` scaffolding.
+- `wfctl editor-schemas` does not export those strict contract descriptors.
+- Runtime HTTP schema endpoints expose module schemas but not a complete editor bundle with steps, contracts, snippets, DSL reference, and config schemas.
+- LSP/plugin schema loading is not yet aligned with the editor bundle, so IDEs and the visual editor can drift.
+
+## Design
+
+### Canonical Editor Bundle
+
+Add a single generated bundle produced by `wfctl editor-bundle` and optionally by `wfctl editor-schemas --bundle`.
+
+```mermaid
+graph LR
+  A[workflow engine registries] --> B[wfctl editor-bundle]
+  C[plugin manifests] --> B
+  D[plugin.contracts.json] --> B
+  E[descriptor sets] --> B
+  B --> F[workflow-editor generated bundle]
+  B --> G[workflow LSP]
+  B --> H[VS Code extension]
+  B --> I[JetBrains plugin]
+```
+
+Bundle contents:
+
+- `version`: Workflow version and bundle schema version.
+- `moduleSchemas`: existing module schema map.
+- `stepSchemas`: existing pipeline step schema map.
+- `coercionRules`: existing compatibility matrix.
+- `contracts`: strict contract registry keyed by plugin, module type, step type, and service.
+- `messages`: normalized message descriptors suitable for UI rendering and validation.
+- `descriptorSets`: references or embedded compressed descriptor material, depending on size.
+- `dslReference`: existing DSL reference JSON.
+- `schemas`: JSON schemas for `app.yaml`, `infra.yaml`, and `wfctl.yaml`.
+- `snippets`: YAML snippets and examples from `wfctl snippets`.
+
+The bundle is the source of truth. `workflow-editor` should keep compatibility wrappers for existing `engine-schemas.json`, but new work should flow through the bundle.
+
+### Contract Shape
+
+Contracts should be normalized for editor usage rather than exposing raw protobuf descriptor internals everywhere.
+
+```typescript
+interface EditorContractBundle {
+  version: string;
+  workflowVersion: string;
+  moduleSchemas: Record<string, EngineModuleSchema>;
+  stepSchemas: Record<string, EngineStepSchema>;
+  coercionRules: Record<string, string[]>;
+  contracts: Record<string, EditorContractDescriptor>;
+  messages: Record<string, EditorMessageDescriptor>;
+  schemas: {
+    app: JsonSchema;
+    infra?: JsonSchema;
+    wfctl?: JsonSchema;
+  };
+  snippets: EditorSnippet[];
+}
+
+interface EditorContractDescriptor {
+  id: string;
+  plugin?: string;
+  ownerType: 'module' | 'step' | 'service';
+  ownerKey: string;
+  mode: 'strict' | 'proto_with_legacy' | 'legacy';
+  requestMessage?: string;
+  responseMessage?: string;
+  configMessage?: string;
+  descriptorSetRef?: string;
+  source: 'builtin' | 'plugin-manifest' | 'plugin-contracts-json' | 'live-plugin';
+}
+```
+
+### Editor Presentation
+
+Node palette:
+
+- Add a compact strict-contract indicator for module and step types with contract descriptors.
+- Group plugin nodes by plugin, preserving existing category grouping.
+- Hide or de-emphasize legacy-only plugin nodes when strict mode is required by project policy.
+
+Node body:
+
+- Show typed input/output labels derived from strict contracts when available.
+- Preserve existing connection handles but derive compatibility from contract output and input message names when stricter than current coercion rules.
+
+Property panel:
+
+- Add a Contract section showing mode, plugin source, request/response/config messages, and descriptor source.
+- Render descriptor-backed config messages as nested typed fields when a field has no better `ConfigFieldDef` mapping.
+- Preserve existing field editors for standard `ConfigFieldDef` fields.
+
+Validation:
+
+- Add live validation against the editor bundle for selected node config and YAML edits.
+- In host environments, expose a callback for `wfctl validate --json` so IDEs can show authoritative diagnostics.
+- Treat strict mode violations as errors and legacy-mode usage under strict policy as warnings or errors based on project config.
+
+### `wfctl.yaml` and IaC Support
+
+Add file-level support rather than treating these as arbitrary YAML:
+
+- `app.yaml` / `app.yml`: Workflow application DSL.
+- `infra.yaml` / `infra.yml`: provider/project infrastructure DSL where present.
+- `wfctl.yaml` / `wfctl.yml`: project tool config, plugin lock policy, validation policy, registries, environments, secrets sinks, and release/deploy defaults.
+
+The editor should expose these files as tabs or workspace resources, not just as imported application fragments.
+
+IaC support should include:
+
+- Top-level `infrastructure` and `sidecars` visualization.
+- Provider, environment, and state-store metadata display.
+- Provider-specific extension panels only when the bundle exposes provider capabilities.
+- Destructive operation policy metadata for future human-in-the-loop deploy gates.
+
+### IDE Integration
+
+VS Code and JetBrains should:
+
+- Associate `wfctl.yaml`, `wfctl.yml`, `infra.yaml`, and `infra.yml` with schemas.
+- Start or invoke `wfctl` to generate the same editor bundle used by the visual editor.
+- Pass the bundle into the webview via existing schema callbacks.
+- Surface strict contract diagnostics through LSP or extension diagnostics.
+- Keep editor package bumps independent from Workflow releases when only webview/editor code changed.
+
+## Compatibility
+
+- Existing `engine-schemas.json` remains readable.
+- Existing `onSchemaRequest` and `onPluginSchemaRequest` stay supported.
+- New hosts should prefer `onEditorBundleRequest`.
+- Legacy plugins still render, but strict-mode project policy can warn or block them.
+- Bundle schema versioning must be explicit so IDE plugins can reject unsupported bundles cleanly.
+
+## Acceptance Criteria
+
+- `wfctl editor-bundle --output editor-bundle.json` includes modules, steps, coercion rules, contracts, messages, DSL reference, snippets, and YAML schemas.
+- `workflow-editor` loads a bundle and renders strict contract metadata for at least one built-in strict contract and one plugin-provided strict contract.
+- Contract metadata round-trips through node selection, property panel editing, YAML serialization, and validation.
+- `wfctl.yaml` and IaC YAML files have schema support in the editor and both IDE plugins.
+- Tests prove strict, proto-with-legacy, and legacy contract modes display and validate correctly.
+- IDE plugins can consume a newer editor package release without requiring a new Workflow release.

--- a/docs/plans/2026-04-27-strict-grpc-contract-editor-support-implementation.md
+++ b/docs/plans/2026-04-27-strict-grpc-contract-editor-support-implementation.md
@@ -1,0 +1,155 @@
+---
+status: ready-for-implementation
+implementation_status: not-started
+depends_on:
+  - docs/plans/2026-04-27-strict-grpc-contract-editor-support-design.md
+  - Workflow PR 500 merged
+---
+
+# Strict gRPC Contract Editor Support Implementation Plan
+
+> **For agents:** REQUIRED SUB-SKILLS: use `superpowers:executing-plans`, `superpowers:test-driven-development`, `superpowers:subagent-driven-development`, `superpowers:requesting-code-review`, and `superpowers:verification-before-completion`. Use an implementer plus an antagonistic code reviewer. Do not start this implementation until the current Workflow checksum PR is merged or explicitly cleared.
+
+**Goal:** Make strict gRPC go-plugin contracts first-class in `wfctl` editor exports, `workflow-editor`, and IDE integrations.
+
+**Design Doc:** `docs/plans/2026-04-27-strict-grpc-contract-editor-support-design.md`
+
+## Phase 1: Workflow Export Contract Bundle
+
+**Repo:** workflow
+
+1. Add tests for a new canonical editor bundle export.
+   - Cover built-in module schemas.
+   - Cover step schemas.
+   - Cover strict contract descriptors.
+   - Cover descriptor/message metadata.
+   - Cover `app.yaml`, `infra.yaml`, and `wfctl.yaml` schemas.
+
+2. Implement bundle types in the Workflow/wfctl schema export package.
+   - Reuse existing module, step, coercion, DSL reference, and snippets producers.
+   - Normalize strict contract registry data into editor-facing contract descriptors.
+   - Include a bundle schema version.
+
+3. Add `wfctl editor-bundle`.
+   - Flags: `--output`, `--plugin-dir`, `--registry`, `--format json`.
+   - Preserve `wfctl editor-schemas` for backwards compatibility.
+   - Add `wfctl editor-schemas --bundle` only if it fits existing CLI conventions cleanly.
+
+4. Add runtime API support if the existing Workflow HTTP management API is expected to feed browser-hosted editors.
+   - Endpoint: `/api/v1/admin/editor-bundle`.
+   - Keep module schema endpoint stable.
+
+5. Verification:
+   - `GOWORK=off go test ./cmd/wfctl ./...` with focused packages first.
+   - `wfctl editor-bundle --output /tmp/editor-bundle.json`.
+   - Validate generated JSON against a bundle schema.
+
+## Phase 2: Editor Bundle Loading
+
+**Repo:** workflow-editor
+
+1. Add failing tests for bundle loading.
+   - `load-schemas` reads module, step, coercion, contract, message, and schema sections.
+   - Existing engine schema loading still works.
+   - Plugin contract overlays do not erase built-in types unless they own the same key.
+
+2. Add editor bundle TypeScript types.
+   - `EditorContractBundle`
+   - `EditorContractDescriptor`
+   - `EditorMessageDescriptor`
+   - `EditorYamlSchemas`
+
+3. Extend `WorkflowEditorProps`.
+   - Add `onEditorBundleRequest?: () => Promise<EditorContractBundle | null>`.
+   - Keep `onSchemaRequest` and `onPluginSchemaRequest`.
+   - Prefer bundle when available.
+
+4. Extend stores.
+   - Add contract/message state to `moduleSchemaStore` or a dedicated `contractSchemaStore`.
+   - Keep selectors cheap for node rendering and property panel lookup.
+
+5. Verification:
+   - `npm test -- src/generated src/stores`.
+   - `npm run build`.
+
+## Phase 3: Contract UI and Validation
+
+**Repo:** workflow-editor
+
+1. Write tests before UI code.
+   - Palette displays plugin strict mode metadata.
+   - Node body displays typed contract input/output names.
+   - Property panel shows Contract section for strict/proto-with-legacy/legacy modes.
+   - Validation flags strict-mode config and connection violations.
+
+2. Implement UI.
+   - Palette strict indicator and plugin grouping.
+   - Contract section in `PropertyPanel`.
+   - Descriptor-backed nested fields for config messages where no `ConfigFieldDef` exists.
+   - Connection compatibility checks that prefer strict contract message compatibility when present.
+
+3. Add YAML validation.
+   - Live validation for selected node config against bundle schemas.
+   - Host callback path for authoritative `wfctl validate --json` diagnostics.
+
+4. Verification:
+   - `npm test`.
+   - `npm run build`.
+   - `npm run test:e2e` after adding a bundle-backed E2E fixture.
+
+## Phase 4: `wfctl.yaml` and IaC Authoring
+
+**Repos:** workflow, workflow-editor
+
+1. Add or export JSON schemas for:
+   - `app.yaml`
+   - `infra.yaml`
+   - `wfctl.yaml`
+
+2. Add editor tests for file-type recognition.
+   - `wfctl.yaml` opens as project config.
+   - `infra.yaml` opens as IaC config.
+   - `app.yaml` behavior is unchanged.
+
+3. Add UI affordances.
+   - Workspace/file tab metadata for app, infra, and wfctl files.
+   - IaC/provider metadata panels.
+   - Future destructive-change policy metadata fields without implementing deploy gating in this task.
+
+4. Verification:
+   - YAML round-trip tests for all three file types.
+   - E2E fixture with `app.yaml`, `infra.yaml`, and `wfctl.yaml`.
+
+## Phase 5: IDE Plugin Integration
+
+**Repos:** workflow-vscode, workflow-jetbrains
+
+1. VS Code:
+   - Add YAML associations for `wfctl.yaml`, `wfctl.yml`, `infra.yaml`, and `infra.yml`.
+   - Add editor bundle generation/loading.
+   - Add diagnostics bridge for strict contract validation.
+   - Add tests for activation and schema association.
+
+2. JetBrains:
+   - Add file recognition/schema association for `wfctl.yaml`, `wfctl.yml`, `infra.yaml`, and `infra.yml`.
+   - Pass editor bundle data into webview.
+   - Add compatibility verification matrix matching declared IDE support.
+
+3. Verification:
+   - VS Code extension compile/test/package.
+   - JetBrains Gradle test/build/plugin verifier.
+   - Manual smoke in both IDEs with a strict-contract sample project.
+
+## Phase 6: Release Path
+
+1. Release Workflow with `wfctl editor-bundle`.
+2. Sync generated bundle into `workflow-editor`.
+3. Release `workflow-editor` independently.
+4. Trigger IDE plugin syncs.
+5. Verify VS Code and JetBrains consume the editor release without requiring another Workflow release.
+
+## Rollback
+
+- Keep `engine-schemas.json` and old callbacks in place for one release train.
+- If bundle loading fails, editor logs a warning and falls back to generated engine schemas.
+- If IDE bundle generation fails, extensions continue to open YAML and use static schema associations.


### PR DESCRIPTION
## Summary

Adds design and implementation plans for two follow-up workstreams:

- strict gRPC go-plugin contract support across wfctl editor exports, workflow-editor, and IDE plugins
- editor/IDE quality, Playwright, compatibility, and editor-only release independence

These docs intentionally gate implementation until Workflow PR 500 is merged or explicitly cleared.

## Notes

Baseline check in a fresh worktree:

- `npm install` completed
- `npm test -- --runInBand` was invalid because Vitest does not support that Jest flag
- `npm test` currently fails locally under Node 25 because test storage mocks expose an invalid localStorage shape to Zustand persistence; the quality plan captures this as Phase 1 work. CI pins Node 22.

## Verification

- `git diff --cached --check` before commit
- ASCII scan for new docs
