### PR TITLE
chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist/
 *.tsbuildinfo
 data/
 test-results/
+_worktrees/
+.worktrees/
+.claude/worktrees/
 *.tgz
 *.tar.gz
 *.zip


### PR DESCRIPTION
## Summary
- ignore local `_worktrees/`, `.worktrees/`, and `.claude/worktrees/` directories
- prevent future agent worktrees from polluting editor repo status

## Verification
- `git check-ignore -v _worktrees/ .worktrees/ .claude/worktrees/`
- `git diff --check`
