### PR TITLE
feat: preserve module satisfies metadata

### DIFF
--- a/src/__tests__/editor-integration.test.ts
+++ b/src/__tests__/editor-integration.test.ts
@@ -86,6 +86,29 @@ triggers: {}
     expect(names).toContain('health-handler');
   });
 
+  it('round-trips module satisfies keys for derived IaC modules', () => {
+    const { config, yaml } = roundTrip(`
+modules:
+  - name: otel-collector
+    type: infra.otel_collector
+    satisfies:
+      - observability.telemetry.default
+      - observability.metrics.default
+    config:
+      endpoint: "\${OTEL_EXPORTER_OTLP_ENDPOINT}"
+workflows: {}
+triggers: {}
+`);
+
+    const collector = config.modules.find((m) => m.name === 'otel-collector');
+    expect(collector?.satisfies).toEqual([
+      'observability.telemetry.default',
+      'observability.metrics.default',
+    ]);
+    expect(yaml).toContain('satisfies:');
+    expect(yaml).toContain('observability.telemetry.default');
+  });
+
   it('adding a node and exporting produces 4 modules', () => {
     const { nodes, edges, parsed } = roundTrip(httpYaml);
     // Simulate adding a middleware node

--- a/src/components/properties/PropertyPanel.test.tsx
+++ b/src/components/properties/PropertyPanel.test.tsx
@@ -133,6 +133,55 @@ describe('PropertyPanel', () => {
     expect(updatedNode?.data.label).toBe('My Custom Server');
   });
 
+  it('edits module satisfies keys outside config', () => {
+    act(() => {
+      useModuleSchemaStore.getState().loadEditorBundle({
+        version: 'editor-bundle/v1',
+        moduleSchemas: {
+          'infra.otel_collector': {
+            type: 'infra.otel_collector',
+            label: 'OTel Collector',
+            category: 'observability',
+            configFields: [],
+            defaultConfig: {},
+          },
+        },
+        coercionRules: {},
+        contracts: {},
+        messages: {},
+        schemas: { app: {} },
+      });
+      useWorkflowStore.setState({
+        nodes: [{
+          id: 'otel-collector',
+          type: 'observabilityNode',
+          position: { x: 0, y: 0 },
+          data: {
+            moduleType: 'infra.otel_collector',
+            label: 'otel-collector',
+            config: {},
+            satisfies: ['observability.telemetry.default'],
+          },
+        }],
+        selectedNodeId: 'otel-collector',
+      });
+    });
+
+    render(<PropertyPanel />);
+
+    const satisfiesInput = screen.getByLabelText('Satisfies');
+    fireEvent.change(satisfiesInput, {
+      target: { value: 'observability.telemetry.default\nobservability.metrics.default' },
+    });
+
+    const updatedNode = useWorkflowStore.getState().nodes.find((n) => n.id === 'otel-collector');
+    expect(updatedNode?.data.satisfies).toEqual([
+      'observability.telemetry.default',
+      'observability.metrics.default',
+    ]);
+    expect(updatedNode?.data.config.satisfies).toBeUndefined();
+  });
+
   it('close button clears selection', () => {
     act(() => {
       useWorkflowStore.getState().addNode('http.server', { x: 0, y: 0 });

--- a/src/components/properties/PropertyPanel.tsx
+++ b/src/components/properties/PropertyPanel.tsx
@@ -59,6 +59,7 @@ export default function PropertyPanel() {
   const selectedNodeId = useWorkflowStore((s) => s.selectedNodeId);
   const updateNodeConfig = useWorkflowStore((s) => s.updateNodeConfig);
   const updateNodeName = useWorkflowStore((s) => s.updateNodeName);
+  const updateNodeSatisfies = useWorkflowStore((s) => s.updateNodeSatisfies);
   const removeNode = useWorkflowStore((s) => s.removeNode);
   const setSelectedNode = useWorkflowStore((s) => s.setSelectedNode);
 
@@ -476,6 +477,18 @@ export default function PropertyPanel() {
             })}
           </div>
         )}
+
+        {/* Module requirement keys */}
+        <label style={{ display: 'block', marginBottom: 16 }}>
+          <span style={{ color: '#a6adc8', fontSize: 11, display: 'block', marginBottom: 4 }}>Satisfies</span>
+          <textarea
+            aria-label="Satisfies"
+            value={((node.data.satisfies as string[] | undefined) ?? []).join('\n')}
+            onChange={(e) => updateNodeSatisfies(node.id, e.target.value.split('\n'))}
+            rows={Math.max(2, ((node.data.satisfies as string[] | undefined)?.length ?? 1))}
+            style={{ ...inputStyle, resize: 'vertical', fontFamily: 'monospace' }}
+          />
+        </label>
 
         {/* I/O Signature */}
         {info?.ioSignature && (info.ioSignature.inputs.length > 0 || info.ioSignature.outputs.length > 0) && (

--- a/src/stores/workflowStore.ts
+++ b/src/stores/workflowStore.ts
@@ -31,6 +31,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   moduleType: string;
   label: string;
   config: Record<string, unknown>;
+  satisfies?: string[];
   synthesized?: boolean;
   /** Source file path this node originated from (multi-file configs) */
   sourceFile?: string;
@@ -93,6 +94,7 @@ interface WorkflowStore {
   removeNode: (id: string) => void;
   updateNodeConfig: (id: string, config: Record<string, unknown>) => void;
   updateNodeName: (id: string, name: string) => void;
+  updateNodeSatisfies: (id: string, satisfies: string[]) => void;
   updateHandlerRoutes: (nodeId: string, routes: Array<{
     method: string;
     path: string;
@@ -449,6 +451,16 @@ const useWorkflowStore = create<WorkflowStore>()(
     set({
       nodes: get().nodes.map((n) =>
         n.id === id ? { ...n, data: { ...n.data, label: name } } : n
+      ),
+    });
+  },
+
+  updateNodeSatisfies: (id, satisfies) => {
+    get().pushHistory();
+    const next = satisfies.map((key) => key.trim()).filter(Boolean);
+    set({
+      nodes: get().nodes.map((n) =>
+        n.id === id ? { ...n, data: { ...n.data, satisfies: next } } : n
       ),
     });
   },

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -6,6 +6,7 @@ export interface ModuleConfig {
   type: string;
   config?: Record<string, unknown>;
   dependsOn?: string[];
+  satisfies?: string[];
   branches?: Record<string, string>;
   ui_position?: { x: number; y: number };
 }

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -294,6 +294,10 @@ export function nodesToConfig(
       mod.config = { ...node.data.config };
     }
 
+    if (node.data.satisfies && node.data.satisfies.length > 0) {
+      mod.satisfies = [...node.data.satisfies];
+    }
+
     const deps = dependencyMap[node.id];
     if (deps && deps.length > 0) {
       mod.dependsOn = deps;
@@ -575,6 +579,7 @@ export function configToNodes(
         moduleType: mod.type,
         label: mod.name,
         config: mod.config ?? (info ? { ...info.defaultConfig } : {}),
+        ...(mod.satisfies && mod.satisfies.length > 0 ? { satisfies: [...mod.satisfies] } : {}),
         ...(sourceFile ? { sourceFile } : {}),
       },
     });


### PR DESCRIPTION
## Summary
- preserve `modules[].satisfies` through YAML parse, graph node state, and YAML export
- add a property-panel editor for module satisfies keys without storing them in `config`
- add serialization and property-panel regression tests for derived IaC requirement keys

## Verification
- npm test -- src/__tests__/editor-integration.test.ts src/components/properties/PropertyPanel.test.tsx src/stores/workflowStore.test.ts
- npm test
- npm run build

## Notes
- `npm run lint` currently fails before linting because ESLint 9 cannot find `eslint.config.*`; this appears to be an existing repo tooling mismatch.