### PR TITLE
ci: publish workflow-editor release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,8 @@ jobs:
       - run: npm test
       - run: npm run build
       - run: bash scripts/package-release-artifacts.sh
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-editor-release-artifacts
+          path: release-artifacts/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,4 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm test
       - run: npm run build
+      - run: bash scripts/package-release-artifacts.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,13 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm test
       - run: npm run build
+      - run: bash scripts/package-release-artifacts.sh
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.version }}
+          files: release-artifacts/*
+          generate_release_notes: true
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-schema.yml
+++ b/.github/workflows/sync-schema.yml
@@ -55,6 +55,7 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm test
       - run: npm run build
+      - run: bash scripts/package-release-artifacts.sh
 
       - name: Publish to GitHub Packages
         run: npm publish || echo "Publish failed (version may already exist)"
@@ -67,16 +68,26 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet && echo "No changes" && exit 0
-          git commit -m "chore: sync types to workflow ${WORKFLOW_VERSION}"
-          git pull --rebase origin master
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes"
+          else
+            git commit -m "chore: sync types to workflow ${WORKFLOW_VERSION}"
+            git pull --rebase origin master
+            git push
+          fi
           if git ls-remote --tags origin "refs/tags/${WORKFLOW_VERSION}" | grep -q .; then
             echo "Tag ${WORKFLOW_VERSION} already exists on remote, skipping"
           else
             git tag "${WORKFLOW_VERSION}"
             git push origin "${WORKFLOW_VERSION}"
           fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.client_payload.version }}
+          files: release-artifacts/*
+          generate_release_notes: true
 
   notify-consumers:
     name: Notify IDE Plugins

--- a/.github/workflows/sync-schema.yml
+++ b/.github/workflows/sync-schema.yml
@@ -55,16 +55,11 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm test
       - run: npm run build
-      - run: bash scripts/package-release-artifacts.sh
-
-      - name: Publish to GitHub Packages
-        run: npm publish || echo "Publish failed (version may already exist)"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit and tag
         run: |
           WORKFLOW_VERSION="${{ github.event.client_payload.version }}"
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
@@ -72,7 +67,7 @@ jobs:
             echo "No changes"
           else
             git commit -m "chore: sync types to workflow ${WORKFLOW_VERSION}"
-            git pull --rebase origin master
+            git pull --rebase origin "${DEFAULT_BRANCH}"
             git push
           fi
           if git ls-remote --tags origin "refs/tags/${WORKFLOW_VERSION}" | grep -q .; then
@@ -81,6 +76,14 @@ jobs:
             git tag "${WORKFLOW_VERSION}"
             git push origin "${WORKFLOW_VERSION}"
           fi
+
+      - run: npm run build
+      - run: bash scripts/package-release-artifacts.sh
+
+      - name: Publish to GitHub Packages
+        run: npm publish || echo "Publish failed (version may already exist)"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _worktrees/
 *.tar.gz
 *.zip
 *.gz
+release-artifacts/

--- a/scripts/package-release-artifacts.sh
+++ b/scripts/package-release-artifacts.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+VERSION="$(node -p "require('./package.json').version")"
+OUT_DIR="release-artifacts"
+DIST_ZIP="${OUT_DIR}/workflow-editor-${VERSION}-dist.zip"
+
+if [ ! -d dist ]; then
+  echo "dist/ is missing; run npm run build first" >&2
+  exit 1
+fi
+
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
+
+npm pack --pack-destination "${OUT_DIR}"
+
+zip -qr "${DIST_ZIP}" \
+  dist \
+  schemas \
+  package.json \
+  README.md \
+  LICENSE \
+  CHANGELOG.md
+
+echo "Created release artifacts:"
+find "${OUT_DIR}" -maxdepth 1 -type f -print | sort


### PR DESCRIPTION
## Summary
- add a reusable release artifact packaging script for npm tarball + dist zip
- upload artifacts from build, schema-sync, and manual publish workflows
- keep schema-sync tag creation idempotent when regenerated files are already current

## Validation
- npm ci
- npm test
- npm run build
- bash scripts/package-release-artifacts.sh
- git diff --check